### PR TITLE
모달 컴포넌트를 감싸는 불필요한 컴포넌트 제거

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -21,11 +21,7 @@ export function Modal({ isOpen, isFadeIn, duration, closeModal, children }) {
   return (
     <>
       {isOpen && (
-        <Overlay
-          isFadeIn={isFadeIn}
-          duration={duration}
-          closeModal={closeModal}
-        >
+        <Overlay isFadeIn={isFadeIn} duration={duration} onClick={closeModal}>
           {children}
         </Overlay>
       )}
@@ -33,15 +29,7 @@ export function Modal({ isOpen, isFadeIn, duration, closeModal, children }) {
   );
 }
 
-function Overlay({ isFadeIn, duration, closeModal, children }) {
-  return (
-    <Wrapper isFadeIn={isFadeIn} duration={duration} onClick={closeModal}>
-      {children}
-    </Wrapper>
-  );
-}
-
-const Wrapper = styled.div`
+const Overlay = styled.div`
   position: fixed;
   top: 0px;
   left: 0px;


### PR DESCRIPTION
# 개요 
- 모달 컴포넌트가 불필요한(없어도 되는) 커스텀 컴포넌트로 감싸져 있던 것을 제거하였다.
- 기존의 커스텀 컴포넌트는 styled component로 대체하였다.

