### PR TITLE
모달 속 컴포넌트를 눌러도 모달 창이 닫히는 버그 수정

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -22,7 +22,9 @@ export function Modal({ isOpen, isFadeIn, duration, closeModal, children }) {
     <>
       {isOpen && (
         <Overlay isFadeIn={isFadeIn} duration={duration} onClick={closeModal}>
-          {children}
+          <Wrapper onClick={(event) => event.stopPropagation()}>
+            {children}
+          </Wrapper>
         </Overlay>
       )}
     </>
@@ -43,6 +45,7 @@ const Overlay = styled.div`
   animation: ${(props) => (props.isFadeIn ? fadeIn : fadeOut)};
   animation-duration: ${(props) => `${props.duration + 100}ms`};
 `;
+const Wrapper = styled.div``;
 
 const fadeIn = keyframes`
   0% {


### PR DESCRIPTION
# 개요 
- 모달은 overlay 영역을 눌렀을 때 닫히게 구현했는데, 내부 컴포넌트를 눌러도 모달이 닫힌다.

# 원인
- 이벤트 버블링 때문에 내부 컴포넌트에서 overlay까지 이벤트가 전달된다.

# 해결
- 내부 컴포넌트를 감싸는 컴포넌트를 만들어서 내부 컴포넌트가 click 되면 event.stopPropagation()를 호출했다.